### PR TITLE
Add regulation extraction endpoint and OCR integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Find regulations related to a case. **For backend integration.**
 
 - **POST `/embed/`** - Generate embeddings for text
 - **POST `/similarity/`** - Rank documents by similarity (text-based)
+- **POST `/regulations/extract`** - Fetch + extract regulation text (parser + OCR fallback)
 - **GET `/`** - Root endpoint
 - **GET `/health/`** - Health check
 
@@ -183,6 +184,19 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:5173"]
 # Backend API (new)
 BACKEND_API_URL=https://orca-app-uayze.ondigitalocean.app
 BACKEND_API_KEY=
+
+# Regulation extraction / OCR
+OCR_PRIMARY_PROVIDER=alapi
+OCR_SECONDARY_PROVIDER=none
+ALAPI_BASE_URL=https://alapi.deep.sa
+ALAPI_API_KEY=
+ALAPI_OCR_PATH=/ocr
+SOURCE_WHITELIST_DOMAINS=laws.boe.gov.sa,laws.moj.gov.sa,boe.gov.sa,moj.gov.sa
+EXTRACTION_TIMEOUT_SECONDS=30
+EXTRACTION_MAX_BYTES=15000000
+EXTRACTION_MAX_CHARS=120000
+OCR_MIN_TEXT_CHARS=400
+OCR_STRICT_MODE=false
 ```
 
 ---

--- a/ai_service/app/api/routes/find_related.py
+++ b/ai_service/app/api/routes/find_related.py
@@ -8,6 +8,8 @@ This endpoint is designed specifically for the backend API to call:
 
 from __future__ import annotations
 
+from collections import defaultdict, deque
+
 from fastapi import APIRouter, HTTPException
 from app.core.similarity import SimilarityService
 from app.api.schemas.requests import FindRelatedRequest
@@ -137,14 +139,21 @@ async def find_related_regulations(payload: FindRelatedRequest) -> FindRelatedRe
             )
         
         matched_pairs = ranked_results[0]  # List of (text, score) tuples
-        
+        text_to_indices = defaultdict(deque)
+        for idx, text in enumerate(regulation_texts):
+            text_to_indices[text].append(idx)
+
         # Build response, filtering by threshold
         related_regulations = []
-        for idx, (matched_text, score) in enumerate(matched_pairs):
+        for matched_text, score in matched_pairs:
             if score < payload.threshold:
                 continue
-            
-            reg_id = regulation_ids[idx]
+
+            indices = text_to_indices.get(matched_text)
+            if not indices:
+                continue
+
+            reg_id = regulation_ids[indices.popleft()]
             metadata = regulation_metadata[reg_id]
             
             related_regulations.append(

--- a/ai_service/app/api/routes/regulation_extract.py
+++ b/ai_service/app/api/routes/regulation_extract.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import socket
+from io import BytesIO
+from urllib.parse import urlparse
+
+import httpx
+from bs4 import BeautifulSoup
+from fastapi import APIRouter
+from pypdf import PdfReader
+
+from app.api.schemas.requests import RegulationExtractRequest
+from app.api.schemas.responses import RegulationExtractResponse
+from app.config import settings
+from app.core.ocr.factory import create_ocr_provider
+from app.utils.logger import logger
+
+router = APIRouter()
+
+
+def normalize_text(text: str) -> str:
+    return " ".join((text or "").split()).strip()
+
+
+def hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def is_private_host(hostname: str) -> bool:
+    try:
+        addresses = socket.getaddrinfo(hostname, None)
+    except Exception:
+        return True
+
+    for item in addresses:
+        ip = item[4][0]
+        try:
+            parsed = ipaddress.ip_address(ip)
+        except ValueError:
+            continue
+        if (
+            parsed.is_private
+            or parsed.is_loopback
+            or parsed.is_link_local
+            or parsed.is_reserved
+            or parsed.is_multicast
+        ):
+            return True
+
+    return False
+
+
+def is_whitelisted_url(source_url: str) -> bool:
+    try:
+        parsed = urlparse(source_url)
+    except Exception:
+        return False
+
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+
+    host = parsed.hostname.lower()
+    allowed = any(
+        host == domain or host.endswith(f".{domain}")
+        for domain in settings.source_whitelist_domains
+    )
+    if not allowed:
+        return False
+
+    return not is_private_host(host)
+
+
+def parse_html(content: bytes) -> tuple[str, str]:
+    decoded = content.decode("utf-8", errors="replace")
+    soup = BeautifulSoup(decoded, "html.parser")
+    text = soup.get_text(separator=" ", strip=True)
+    return decoded, text
+
+
+def parse_pdf(content: bytes) -> str:
+    reader = PdfReader(BytesIO(content))
+    extracted = []
+    for page in reader.pages:
+        extracted.append(page.extract_text() or "")
+    return "\n".join(extracted).strip()
+
+
+def parse_plain_text(content: bytes) -> str:
+    return content.decode("utf-8", errors="replace").strip()
+
+
+@router.post("/regulations/extract", response_model=RegulationExtractResponse)
+async def extract_regulation_content(
+    payload: RegulationExtractRequest,
+) -> RegulationExtractResponse:
+    source_url = payload.source_url.strip()
+    if not source_url:
+        return RegulationExtractResponse(
+            status="error",
+            source_url=payload.source_url,
+            extraction_method="none",
+            error_code="empty_source_url",
+            warnings=["Source URL is empty."],
+        )
+
+    if not is_whitelisted_url(source_url):
+        return RegulationExtractResponse(
+            status="error",
+            source_url=source_url,
+            extraction_method="none",
+            error_code="source_not_allowed",
+            warnings=["Source URL is not in the trusted whitelist or resolves to a private network."],
+        )
+
+    headers: dict[str, str] = {}
+    if payload.if_none_match:
+        headers["If-None-Match"] = payload.if_none_match
+    if payload.if_modified_since:
+        headers["If-Modified-Since"] = payload.if_modified_since
+
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=settings.extraction_timeout_seconds,
+        ) as client:
+            response = await client.get(source_url, headers=headers)
+    except Exception as exc:
+        return RegulationExtractResponse(
+            status="error",
+            source_url=source_url,
+            extraction_method="none",
+            error_code="fetch_failed",
+            warnings=[f"Failed to fetch source URL: {exc}"],
+        )
+
+    final_url = str(response.url)
+    etag = response.headers.get("etag")
+    last_modified = response.headers.get("last-modified")
+    content_type = (response.headers.get("content-type") or "").lower()
+
+    if response.status_code == 304:
+        return RegulationExtractResponse(
+            status="not_modified",
+            source_url=source_url,
+            final_url=final_url,
+            etag=etag,
+            last_modified=last_modified,
+            content_type=content_type or None,
+            extraction_method="not_modified",
+            extracted_text=None,
+            normalized_text_hash=None,
+        )
+
+    if response.status_code >= 400:
+        return RegulationExtractResponse(
+            status="error",
+            source_url=source_url,
+            final_url=final_url,
+            etag=etag,
+            last_modified=last_modified,
+            content_type=content_type or None,
+            extraction_method="none",
+            error_code=f"http_{response.status_code}",
+            warnings=[f"Source returned HTTP {response.status_code}"],
+        )
+
+    content = response.content
+    if len(content) > settings.extraction_max_bytes:
+        return RegulationExtractResponse(
+            status="error",
+            source_url=source_url,
+            final_url=final_url,
+            etag=etag,
+            last_modified=last_modified,
+            content_type=content_type or None,
+            extraction_method="none",
+            error_code="payload_too_large",
+            warnings=[f"Fetched payload exceeds {settings.extraction_max_bytes} bytes limit."],
+        )
+
+    parser_text = ""
+    raw_html: str | None = None
+    extraction_method = "parser_text"
+    warnings: list[str] = []
+
+    try:
+        if "text/html" in content_type:
+            raw_html, parser_text = parse_html(content)
+            extraction_method = "parser_html"
+        elif "application/pdf" in content_type or final_url.lower().endswith(".pdf"):
+            parser_text = parse_pdf(content)
+            extraction_method = "parser_pdf"
+        elif content_type.startswith("text/"):
+            parser_text = parse_plain_text(content)
+            extraction_method = "parser_text"
+        else:
+            parser_text = parse_plain_text(content)
+            extraction_method = "parser_fallback"
+    except Exception as exc:
+        warnings.append(f"Parser failed: {exc}")
+        parser_text = ""
+
+    parsed_length = len(normalize_text(parser_text))
+    needs_ocr = (
+        parsed_length < settings.ocr_min_text_chars
+        and (
+            "application/pdf" in content_type
+            or content_type.startswith("image/")
+            or final_url.lower().endswith(".pdf")
+        )
+    )
+
+    ocr_provider_used = "none"
+    fallback_stage = "none"
+    final_text = parser_text
+
+    if needs_ocr:
+        primary_provider = create_ocr_provider(settings.ocr_primary_provider)
+        primary = await primary_provider.extract_text(
+            content=content,
+            content_type=content_type or "application/octet-stream",
+            file_name="regulation-source",
+        )
+        if primary.ok and primary.text:
+            final_text = primary.text
+            extraction_method = "ocr_primary"
+            ocr_provider_used = primary.provider
+        else:
+            warnings.append(primary.error or "Primary OCR provider failed.")
+            fallback_stage = "secondary"
+            secondary_provider = create_ocr_provider(settings.ocr_secondary_provider)
+            secondary = await secondary_provider.extract_text(
+                content=content,
+                content_type=content_type or "application/octet-stream",
+                file_name="regulation-source",
+            )
+            if secondary.ok and secondary.text:
+                final_text = secondary.text
+                extraction_method = "ocr_secondary"
+                ocr_provider_used = secondary.provider
+            else:
+                warnings.append(secondary.error or "Secondary OCR provider failed.")
+                fallback_stage = "parser_only"
+                extraction_method = f"{extraction_method}_fallback"
+                ocr_provider_used = "none"
+
+    max_chars = payload.max_chars or settings.extraction_max_chars
+    normalized = normalize_text(final_text)
+    if len(normalized) > max_chars:
+        normalized = normalized[:max_chars]
+        warnings.append(f"Extracted text truncated to {max_chars} chars.")
+
+    if not normalized:
+        if settings.ocr_strict_mode:
+            return RegulationExtractResponse(
+                status="error",
+                source_url=source_url,
+                final_url=final_url,
+                etag=etag,
+                last_modified=last_modified,
+                content_type=content_type or None,
+                extraction_method=extraction_method,
+                ocr_provider_used=ocr_provider_used,
+                fallback_stage=fallback_stage,
+                error_code="empty_extracted_text",
+                warnings=warnings or ["No text could be extracted."],
+            )
+        warnings.append("No text could be extracted. Returning empty content in non-strict mode.")
+
+    logger.info(
+        "Regulation extraction completed",
+        extra={
+            "source_url": source_url,
+            "final_url": final_url,
+            "method": extraction_method,
+            "ocr_provider": ocr_provider_used,
+            "fallback_stage": fallback_stage,
+            "text_len": len(normalized),
+        },
+    )
+
+    return RegulationExtractResponse(
+        status="ok",
+        source_url=source_url,
+        final_url=final_url,
+        etag=etag,
+        last_modified=last_modified,
+        content_type=content_type or None,
+        extraction_method=extraction_method,
+        extracted_text=normalized,
+        normalized_text_hash=hash_text(normalized) if normalized else None,
+        raw_html=raw_html,
+        ocr_provider_used=ocr_provider_used,
+        fallback_stage=fallback_stage,
+        warnings=warnings,
+    )

--- a/ai_service/app/api/schemas/requests.py
+++ b/ai_service/app/api/schemas/requests.py
@@ -32,3 +32,10 @@ class FindRelatedRequest(BaseModel):
     regulations: List[RegulationCandidate]
     top_k: int = 10
     threshold: float = 0.3
+
+
+class RegulationExtractRequest(BaseModel):
+    source_url: str
+    if_none_match: Optional[str] = None
+    if_modified_since: Optional[str] = None
+    max_chars: Optional[int] = None

--- a/ai_service/app/api/schemas/responses.py
+++ b/ai_service/app/api/schemas/responses.py
@@ -35,3 +35,20 @@ class FindRelatedResponse(BaseModel):
     related_regulations: List[RelatedRegulation]
     query_length: int
     candidates_count: int
+
+
+class RegulationExtractResponse(BaseModel):
+    status: str
+    source_url: str
+    final_url: Optional[str] = None
+    etag: Optional[str] = None
+    last_modified: Optional[str] = None
+    content_type: Optional[str] = None
+    extraction_method: str
+    extracted_text: Optional[str] = None
+    normalized_text_hash: Optional[str] = None
+    raw_html: Optional[str] = None
+    ocr_provider_used: str = "none"
+    fallback_stage: str = "none"
+    warnings: List[str] = []
+    error_code: Optional[str] = None

--- a/ai_service/app/config.py
+++ b/ai_service/app/config.py
@@ -53,6 +53,52 @@ class Settings(BaseSettings):
         validation_alias="BACKEND_API_KEY",
     )
 
+    # Regulation extraction / OCR
+    ocr_primary_provider: str = Field(
+        default="alapi",
+        validation_alias="OCR_PRIMARY_PROVIDER",
+    )
+    ocr_secondary_provider: str = Field(
+        default="none",
+        validation_alias="OCR_SECONDARY_PROVIDER",
+    )
+    alapi_base_url: str = Field(
+        default="https://alapi.deep.sa",
+        validation_alias="ALAPI_BASE_URL",
+    )
+    alapi_api_key: str = Field(
+        default="",
+        validation_alias="ALAPI_API_KEY",
+    )
+    alapi_ocr_path: str = Field(
+        default="/ocr",
+        validation_alias="ALAPI_OCR_PATH",
+    )
+    source_whitelist_domains: List[str] = Field(
+        default=["laws.boe.gov.sa", "laws.moj.gov.sa", "boe.gov.sa", "moj.gov.sa"],
+        validation_alias="SOURCE_WHITELIST_DOMAINS",
+    )
+    extraction_timeout_seconds: float = Field(
+        default=30.0,
+        validation_alias="EXTRACTION_TIMEOUT_SECONDS",
+    )
+    extraction_max_bytes: int = Field(
+        default=15_000_000,
+        validation_alias="EXTRACTION_MAX_BYTES",
+    )
+    extraction_max_chars: int = Field(
+        default=120_000,
+        validation_alias="EXTRACTION_MAX_CHARS",
+    )
+    ocr_min_text_chars: int = Field(
+        default=400,
+        validation_alias="OCR_MIN_TEXT_CHARS",
+    )
+    ocr_strict_mode: bool = Field(
+        default=False,
+        validation_alias="OCR_STRICT_MODE",
+    )
+
     @field_validator("cors_origins", mode="before")
     @classmethod
     def parse_cors(cls, v: Any) -> Any:
@@ -79,6 +125,27 @@ class Settings(BaseSettings):
                     pass
 
             # Fallback: comma-separated
+            return [item.strip() for item in s.split(",") if item.strip()]
+
+        return v
+
+    @field_validator("source_whitelist_domains", mode="before")
+    @classmethod
+    def parse_domains(cls, v: Any) -> Any:
+        if isinstance(v, list):
+            return v
+
+        if isinstance(v, str):
+            s = v.strip()
+            if not s:
+                return []
+
+            if s.startswith("[") and s.endswith("]"):
+                try:
+                    return json.loads(s)
+                except Exception:
+                    pass
+
             return [item.strip() for item in s.split(",") if item.strip()]
 
         return v

--- a/ai_service/app/core/ocr/__init__.py
+++ b/ai_service/app/core/ocr/__init__.py
@@ -1,0 +1,1 @@
+# OCR utilities package

--- a/ai_service/app/core/ocr/factory.py
+++ b/ai_service/app/core/ocr/factory.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from app.core.ocr.providers.alapi import AlapiOCRProvider
+from app.core.ocr.providers.base import OCRProvider
+from app.core.ocr.providers.none import NoneOCRProvider
+
+
+def create_ocr_provider(name: str) -> OCRProvider:
+    normalized = (name or "").strip().lower()
+    if normalized == "alapi":
+        return AlapiOCRProvider()
+    if normalized in ("none", "disabled", "parser_only", ""):
+        return NoneOCRProvider()
+
+    # Unknown providers are treated as disabled so extraction can still
+    # continue with parser-only fallback.
+    return NoneOCRProvider()

--- a/ai_service/app/core/ocr/providers/__init__.py
+++ b/ai_service/app/core/ocr/providers/__init__.py
@@ -1,0 +1,1 @@
+# OCR provider implementations package

--- a/ai_service/app/core/ocr/providers/alapi.py
+++ b/ai_service/app/core/ocr/providers/alapi.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+from app.config import settings
+from app.core.ocr.providers.base import OCRProvider, OCRResult
+
+
+class AlapiOCRProvider(OCRProvider):
+    name = "alapi"
+
+    def _extract_text_from_json(self, payload: Any) -> Optional[str]:
+        if payload is None:
+            return None
+
+        if isinstance(payload, str):
+            return payload.strip() or None
+
+        if isinstance(payload, list):
+            collected = [self._extract_text_from_json(item) for item in payload]
+            merged = "\n".join(item for item in collected if item)
+            return merged.strip() or None
+
+        if isinstance(payload, dict):
+            for key in ("text", "content", "result", "ocr_text", "extracted_text"):
+                value = payload.get(key)
+                text = self._extract_text_from_json(value)
+                if text:
+                    return text
+            for value in payload.values():
+                text = self._extract_text_from_json(value)
+                if text:
+                    return text
+
+        return None
+
+    async def extract_text(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        file_name: str = "document",
+    ) -> OCRResult:
+        if not settings.alapi_api_key:
+            return OCRResult(
+                ok=False,
+                error="ALAPI_API_KEY is not configured",
+                provider=self.name,
+            )
+
+        base_url = settings.alapi_base_url.rstrip("/")
+        path = settings.alapi_ocr_path.strip()
+        if not path.startswith("/"):
+            path = f"/{path}"
+
+        try:
+            async with httpx.AsyncClient(timeout=settings.extraction_timeout_seconds) as client:
+                response = await client.post(
+                    f"{base_url}{path}",
+                    headers={
+                        "Authorization": f"Bearer {settings.alapi_api_key}",
+                    },
+                    files={
+                        "file": (
+                            file_name,
+                            content,
+                            content_type or "application/octet-stream",
+                        )
+                    },
+                )
+        except Exception as exc:
+            return OCRResult(
+                ok=False,
+                error=f"alapi_request_failed: {exc}",
+                provider=self.name,
+            )
+
+        if response.status_code >= 400:
+            return OCRResult(
+                ok=False,
+                error=f"alapi_http_{response.status_code}",
+                provider=self.name,
+            )
+
+        try:
+            payload = response.json()
+        except Exception:
+            payload = response.text
+
+        text = self._extract_text_from_json(payload)
+        if not text:
+            return OCRResult(
+                ok=False,
+                error="alapi_empty_text",
+                provider=self.name,
+            )
+
+        return OCRResult(ok=True, text=text, provider=self.name)

--- a/ai_service/app/core/ocr/providers/base.py
+++ b/ai_service/app/core/ocr/providers/base.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class OCRResult:
+    ok: bool
+    text: Optional[str] = None
+    error: Optional[str] = None
+    provider: str = "none"
+
+
+class OCRProvider:
+    name = "base"
+
+    async def extract_text(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        file_name: str = "document",
+    ) -> OCRResult:
+        raise NotImplementedError

--- a/ai_service/app/core/ocr/providers/none.py
+++ b/ai_service/app/core/ocr/providers/none.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from app.core.ocr.providers.base import OCRProvider, OCRResult
+
+
+class NoneOCRProvider(OCRProvider):
+    name = "none"
+
+    async def extract_text(
+        self,
+        *,
+        content: bytes,
+        content_type: str,
+        file_name: str = "document",
+    ) -> OCRResult:
+        return OCRResult(
+            ok=False,
+            error="OCR provider is disabled",
+            provider=self.name,
+        )

--- a/ai_service/app/main.py
+++ b/ai_service/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.api.routes import health, embeddings, similarity, find_related
+from app.api.routes import health, embeddings, similarity, find_related, regulation_extract
 
 random.seed(42)
 
@@ -35,4 +35,4 @@ app.include_router(health.router, tags=["health"])
 app.include_router(embeddings.router, tags=["embeddings"])
 app.include_router(similarity.router, tags=["similarity"])
 app.include_router(find_related.router, tags=["similarity"])
-
+app.include_router(regulation_extract.router, tags=["regulation-extraction"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,12 +17,13 @@ numpy>=1.26,<3.0
 # to run tests
 pytest>=8.2,<9.0
 httpx>=0.27,<1.0
+beautifulsoup4>=4.12,<5.0
+pypdf>=4.3,<6.0
 
 # Back-end 
 torch>=2.2.0
 
 # Ai model loader
 sentence-transformers==3.0.1
-
 
 


### PR DESCRIPTION
- Introduced a new endpoint `POST /regulations/extract` for fetching and extracting regulation text.
- Updated README to include the new endpoint and configuration settings for OCR.
- Added configuration options for OCR providers and extraction parameters in the settings.
- Implemented a new OCR provider structure with support for Alapi and a fallback option.
- Enhanced the find_related functionality to improve regulation matching.
- Updated requirements to include `beautifulsoup4` and `pypdf` for HTML and PDF parsing.